### PR TITLE
Fix failing unit tests

### DIFF
--- a/src/test/java/com/makers/project3/model/UserTest.java
+++ b/src/test/java/com/makers/project3/model/UserTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 
 public class UserTest {
 
-    Date birthday = new Date(1999, 12, 31);
+    Date birthday = new Date(1999, Calendar.DECEMBER, 31);
     private User testUser = new User(1L, "test@test.com", "username", "/uploads/profilePics/default.jpg", birthday, 4, 10, "####abcd", 1L);
 
     //    Tests that the user has an associated ID
@@ -35,7 +35,7 @@ public class UserTest {
     //    Tests that the user model saved the profile picture source name correctly
     @Test
     public void userHasPfp() {
-        assertThat(testUser.getImageSource(), equalTo("pfp.jpg"));
+        assertThat(testUser.getImageSource(), equalTo("/uploads/profilePics/default.jpg"));
     }
 
     //    Tests that the user model saved the birthday correctly


### PR DESCRIPTION
While (unsuccessfully) trying to get CI passing, I spotted two of the UserTest unit tests were failing, so I've applied quick fixes:

* `userHasPfp` - it was expecting an image called "pfp.jpg" which isn't what you're injecting into the user - I think this is just outdated / feels like maybe you changed how uploads worked, but hadn't updated the test.
* `userHasBirthday` - this was failing because you were defining the birthday as `Date(1999, 12, 31)` but month numbers are zero-indexed in Java - so the test code was creating a user whose birthday was in the "13th month", which - because Java dates wrap round - meant it was setting their birthday to 31st January. Fixed to use the constant `Calendar.DECEMBER` (same as in the test) for clarity.

If you merge these then your unit tests will all pass, even if I've been unable to fix the Springboot startup issues.

NB if you look at the CI run for this build, at line 1285 you will see that the user tests now fully pass -
```
[INFO] Running com.makers.project3.model.UserTest
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.032 s -- in com.makers.project3.model.UserTest
```